### PR TITLE
New filter `pandoc-include` added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV LANG en_US.UTF-8
 # SSH pre-config / useful for Gitlab CI
 #
 RUN mkdir -p ~/.ssh && \
-    echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
+    echo "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
 
 #
 # Add local cache/. It's empty by default so this does not change the final

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN set -x && \
     fi; \
     apt-get -qq update && \
     apt-get -qy install --no-install-recommends \
+        # for locales and utf-8 support
+        locales \
         # for deployment
         openssh-client \
         rsync \
@@ -58,9 +60,17 @@ RUN set -x && \
         zlibc \
 		# for emojis
 		librsvg2-bin \
+    # add en_US Locale including UTF-8 support
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     # clean up
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/01proxy
+
+#
+# Set Locale for UTF-8 support
+#
+ENV LANG en_US.UTF-8
 
 #
 # SSH pre-config / useful for Gitlab CI

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Note: if SELinux is enabled on you system, you might need to add the
 `--privileged` tag to force access to the mouting points. See
 https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities .
 
+Note: when using the ["pandoc-include"](https://pypi.org/project/pandoc-include) filter to include other files, the working directory `pwd` to mount in docker *should* be a common parent directory of all referenced files to include. As `!include [mypath/myfile.md]` statements within markdown *should* be relative paths, the docker arg `--workdir="my/path/to/markdownfolder"` should be used to name the folder that the markdown file including the includes resides in. Full working example: `docker run --rm -v $(pwd):/pandoc --workdir="/pandoc/my/sub/folder/to-markdown-file" dalibo/pandocker --filter pandoc-include --pdf-engine=xelatex --template=eisvogel --listings --toc --toc-depth=3 ./myfile.md -o myfile-generated.pdf'`
 
 ## Supported Tags
 
@@ -43,7 +44,7 @@ Other tags are not supported and should be used with care.
 
 ## Build it
 
-Use `make` or `docker build`
+Use `make` or `docker build .`
 
 
 ## Embedded template : Eisvogel

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandoc-dalibo-guidelines
 pypdf2
 pandoc-minted
 pygments
+pandoc-include


### PR DESCRIPTION
+ see https://pypi.org/project/pandoc-include/
+ `pandoc-include` allows file includes within a markdown file, so that contents of included file is expanded into generated document

### Usage in markdown file:

Each include statement - i.e. file to include - has its own line and has the syntax:

`!include somefolder/somefile`

Or

`$include somefolder/somefile`

Each include statement must be in its own paragraph. That is, in its own line and separated by blank lines.

The path can be either absolute or relative to current file’s directory.

### Usage for docker:

`docker run [...] --workdir="PATH_TO_MARKDOWN_FILE" [...]  --filter pandoc-include [...]`

+ why `--workdir`?
	+ It is good practice to use relative paths in the `!include` statements.
	+ Therefore, the files to include very well may reside in different (parent) folder(s) than the actual markdown file to convert --> The parent directory/volume to mount in docker (`$(pwd)`) *must* be set to a base folder to reach all the included/referenced files
	+ Docker arg `--workdir` therefore *may* be used to define the folder the markdown file to convert itself resides in.
+ Pandoc arg `--filter pandoc-include` is given to actually use the "pandoc include" feature

Full working example: `docker run --rm -v $(pwd):/pandoc --workdir="/pandoc/my/sub/folder/to-markdown-file" dalibo/pandocker --filter pandoc-include --pdf-engine=xelatex --template=eisvogel --listings --toc --toc-depth=3 ./myfile.md -o myfile-generated.pdf'`