### PR TITLE
Upgrades to pandoc 2.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ADD cache/ ./cache
 #
 # Install pandoc from upstream. Debian package is too old.
 #
-ARG PANDOC_VERSION=2.7
+ARG PANDOC_VERSION=2.7.3
 ADD fetch-pandoc.sh /usr/local/bin/
 RUN fetch-pandoc.sh ${PANDOC_VERSION} ./cache/pandoc.deb && \
     dpkg --install ./cache/pandoc.deb && \


### PR DESCRIPTION
pandoc 2.7.1 adds frontmatter support but might as well bump to the latest.