### PR TITLE
Adds pandoc-crossref at 0.3.6.0, latest for Pandoc 2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ ADD cache/ ./cache
 #
 # Install pandoc from upstream. Debian package is too old.
 #
+# When incrementing this version, also increment
+# PANDOC_CROSSREF_VERSION below.
 ARG PANDOC_VERSION=2.9
 ADD fetch-pandoc.sh /usr/local/bin/
 RUN fetch-pandoc.sh ${PANDOC_VERSION} ./cache/pandoc.deb && \
@@ -106,6 +108,9 @@ RUN pip3 --no-cache-dir install --find-links file://${PWD}/cache -r requirements
 #
 # pandoc-crossref
 #
+# This version must correspond to the correct PANDOC_VERSION.
+# See https://github.com/lierdakil/pandoc-crossref/releases to find the latest
+# release corresponding to the desired pandoc version.
 ARG PANDOC_CROSSREF_VERSION=0.3.6.0
 ADD fetch-pandoc-crossref.sh /usr/local/bin/
 RUN fetch-pandoc-crossref.sh ${PANDOC_VERSION} ${PANDOC_CROSSREF_VERSION} ./cache/pandoc-crossref.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,16 @@ RUN fetch-pandoc.sh ${PANDOC_VERSION} ./cache/pandoc.deb && \
 ADD requirements.txt ./
 RUN pip3 --no-cache-dir install --find-links file://${PWD}/cache -r requirements.txt
 
+#
+# pandoc-crossref
+#
+ARG PANDOC_CROSSREF_VERSION=0.3.6.0
+ADD fetch-pandoc-crossref.sh /usr/local/bin/
+RUN fetch-pandoc-crossref.sh ${PANDOC_VERSION} ${PANDOC_CROSSREF_VERSION} ./cache/pandoc-crossref.tar.gz && \
+    tar xf ./cache/pandoc-crossref.tar.gz && \
+    install pandoc-crossref /usr/local/bin/ && \
+    install -d /usr/local/man/man1 && \
+    install pandoc-crossref.1 /usr/local/man/man1/
 
 #
 # eisvogel template

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 NAME?=dalibo/pandocker
 TAG?=$(shell git branch | grep -e "^*" | cut -d' ' -f 2)
+
+# These versions must be changed together.
+# See https://github.com/lierdakil/pandoc-crossref/releases to find the latest
+# release corresponding to the desired Pandoc version.
 PANDOC_VERSION?=2.9
 PANDOC_CROSSREF_VERSION?=0.3.6.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME?=dalibo/pandocker
 TAG?=$(shell git branch | grep -e "^*" | cut -d' ' -f 2)
 PANDOC_VERSION?=2.9
+PANDOC_CROSSREF_VERSION?=0.3.6.0
 
 all: build
 
@@ -9,6 +10,7 @@ build: Dockerfile
 	docker build \
 	    --build-arg APT_CACHER=$${APT_CACHER-} \
 	    --build-arg PANDOC_VERSION=$(PANDOC_VERSION) \
+	    --build-arg PANDOC_CROSSREF_VERSION=$(PANDOC_CROSSREF_VERSION) \
 	    --tag $(NAME):$(TAG) .
 
 test:
@@ -22,4 +24,5 @@ clean:
 
 warm-cache:
 	./fetch-pandoc.sh $(PANDOC_VERSION) cache/pandoc.deb
+	./fetch-pandoc-crossref.sh $(PANDOC_VERSION) $(PANDOC_CROSSREF_VERSION) cache/pandoc-crossref.tar.gz
 	pip download --dest cache/ --requirement requirements.txt

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ filter below:
 * [pandoc-latex-barcode] : insert barcodes and QRcodes in documents
 * [pandoc-mustache] : basic variables substitution
 * [pandoc-minted] : advanced syntax highlighting
+* [pandoc-crossref] : support for cross-referencing sections, figures, and more
 
 NOTE: By default when using the [pandoc-include] filter, the path to target
 files is relative to the `/pandoc` mountpoint. For instance,
@@ -66,6 +67,7 @@ another location.
 [pandoc-latex-barcode]: https://github.com/daamien/pandoc-latex-barcode
 [pandoc-mustache]: https://github.com/michaelstepner/pandoc-mustache
 [pandoc-minted]: https://github.com/nick-ulle/pandoc-minted
+[pandoc-crossref]: https://github.com/lierdakil/pandoc-crossref
 
 ## Supported Tags
 

--- a/fetch-pandoc-crossref.sh
+++ b/fetch-pandoc-crossref.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eux
+
+PANDOC_VERSION=$1
+# pandoc-crossref's binaries ship with the pandoc version in the artifact, underscores instead of periods
+CROSSREF_PANDOC_VERSION_ID="$(echo "${PANDOC_VERSION}" | tr '.' '_')"
+PANDOC_CROSSREF_VERSION=$2
+DEST=${3-pandoc_crossref.tar.gz}
+URL=https://github.com/lierdakil/pandoc-crossref/releases/download/v${PANDOC_CROSSREF_VERSION}/linux-pandoc_${CROSSREF_PANDOC_VERSION_ID}.tar.gz
+
+exec wget --continue --timestamping --output-document ${DEST} ${URL}


### PR DESCRIPTION
Fixes #122

Combined with #125, this builds my document that needs both `pandoc-citeproc` and `pandoc-crossref`!