### PR TITLE
Updated pandoc and pandoc-crossref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ TAG?=$(shell git branch | grep -e "^*" | cut -d' ' -f 2)
 # These versions must be changed together.
 # See https://github.com/lierdakil/pandoc-crossref/releases to find the latest
 # release corresponding to the desired Pandoc version.
-PANDOC_VERSION?=2.14.1
-CROSSREF_VERSION?=0.3.12.0b
+PANDOC_VERSION?=2.17.0.1
+CROSSREF_VERSION?=0.3.12.2
 
 # Bats
 # We use bats-core instead of the original bats

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/latex:2.14.1
+FROM pandoc/latex:2.17.0.1
 
 RUN apk --no-cache add \
         bash \
@@ -108,7 +108,7 @@ RUN pip3 --no-cache-dir install -r requirements.txt
 # See https://github.com/lierdakil/pandoc-crossref/releases to find the latest
 # release corresponding to the desired pandoc version.
 ARG CROSSREF_REPO=https://github.com/lierdakil/pandoc-crossref/releases/download/
-ARG CROSSREF_VERSION=0.3.12.0b
+ARG CROSSREF_VERSION=0.3.12.2
 RUN wget ${CROSSREF_REPO}/v${CROSSREF_VERSION}/pandoc-crossref-Linux.tar.xz -O /tmp/pandoc-crossref.tar.xz && \
     tar xf /tmp/pandoc-crossref.tar.xz && \
     install pandoc-crossref /usr/local/bin/

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -96,7 +96,7 @@ ADD cache/ ./cache
 #
 # When incrementing this version, also increment
 # PANDOC_CROSSREF_VERSION below.
-ARG PANDOC_VERSION=2.14.1
+ARG PANDOC_VERSION=2.17.0.1
 ADD fetch-pandoc.sh /usr/local/bin/
 RUN fetch-pandoc.sh ${PANDOC_VERSION} ./cache/pandoc.deb && \
     dpkg --install ./cache/pandoc.deb && \
@@ -140,7 +140,7 @@ RUN pip3 --no-cache-dir install --find-links file://${PWD}/cache -r requirements
 # See https://github.com/lierdakil/pandoc-crossref/releases to find the latest
 # release corresponding to the desired pandoc version.
 ARG CROSSREF_REPO=https://github.com/lierdakil/pandoc-crossref/releases/download/
-ARG CROSSREF_VERSION=0.3.12.0b
+ARG CROSSREF_VERSION=0.3.12.2
 RUN wget ${CROSSREF_REPO}/v${CROSSREF_VERSION}/pandoc-crossref-Linux.tar.xz -O /tmp/pandoc-crossref.tar.xz && \
     tar xf /tmp/pandoc-crossref.tar.xz && \
     install pandoc-crossref /usr/local/bin/ && \


### PR DESCRIPTION
Hi there,

thanks for providing this image, it's great to use and helps us a lot.

We have been running into issues lately with embedding styled .svg files. They fail with errors like below:
```
[WARNING] Could not convert image /tmp/tex2pdf.-d1a172ffd03ab359/input.svg: conversion from SVG failed
parsing error: 1:2180:could not recognize next production
parsing error: 1:2210:while parsing rulset: current char must be a '}'
```

It seems this is a bug from librsvg, which was handled in here: https://gitlab.gnome.org/GNOME/librsvg/-/issues/428
The fix was released in librsvg 2.47.1, but with pandocker being based on pandoc/latex:2.14.1, it seems this fix is not yet incorporated.

I updated the versions for pandoc/latex and pandoc-crossref, which should as result also update librsvg, as the latest pandoc/latex images builds up on alpine 3.14, which offers librsvg in a version which includes the fix: https://pkgs.alpinelinux.org/packages?name=librsvg&branch=v3.14

I hope this all makes sense to you. It built successfully at my side.

Kind regards,
Florian