### PR TITLE
Adds draftwatermark and glossaries latex packages

### DIFF
--- a/latex_requirements.txt
+++ b/latex_requirements.txt
@@ -101,3 +101,6 @@ minted
 
 # https://github.com/dalibo/pandocker/issues/238#issuecomment-1287170507
 enumitem
+
+draftwatermark
+glossaries


### PR DESCRIPTION
These were present in past versions of pandocker.

Our workaround in CI until this is in a release of stable or latest is to install these packages before our pandoc invocation:

```
tlmgr install draftwatermark glossaries
```