### PR TITLE
Fix for Dockerfile smell DL4006

### DIFF
--- a/ubuntu-full/Dockerfile
+++ b/ubuntu-full/Dockerfile
@@ -17,6 +17,7 @@ ENV DEBCONF_NOWARNINGS yes
 #
 # Debian
 #
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x && \
     # Setup a cacher to speed up build
     if [ -n "${APT_CACHER}" ] ; then \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "ubuntu-full/Dockerfile" contains the best practice violation [DL4006](https://github.com/hadolint/hadolint/wiki/DL4006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL4006 occurs when there is a RUN instruction with a pipe in and the `-o pipefail` option is missing. The issue is that the RUN instruction only evaluates the exit code of the last operation in the pipe to determine success. Thus, during the Docker build, if one of the statements contained in the RUN instruction fails but not the last, the build will continue even if there is an error.
This pull request proposes a fix generated by a fixing tool that I developed to fix this kind of smell. The patch was manually verified before opening the pull request. To fix this smell, specifically, the option `-o pipefail` is placed before the RUN instruction with a pipe in.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
