### PR TITLE
Adds glossaries-extra to tlmgr packages

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -46,3 +46,4 @@ enumitem
 
 draftwatermark
 glossaries
+glossaries-extra


### PR DESCRIPTION
I've started using this on top of / instead of glossaries, mostly because of its ability to reset glossary short-forms per-chapter with some extra code, e.g. https://github.com/tomncooper/pandoc-gls/pull/12